### PR TITLE
basic serverside rendering script

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
 <title>DevTools Protocol Viewer</title>
+<base href="/">
 <link rel="stylesheet" href="./style.css">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <script src="search.js"></script>

--- a/main.js
+++ b/main.js
@@ -25,7 +25,7 @@ class App {
     /** @type {!Map<string, !Object>} */
     this._stableDomains = new Map();
     this._search = new Search(document.getElementById('search'), document.getElementById('sresults'));
-    this._router = new Router(route => this._renderError);
+    this._router = new Router(route => this._contentElement.appendChild(renderError(`Route (${route}) not matched`)));
     this._router.setRoute(/^(\w+)(?:\.(\w+))?$/, (route, domain, method) => this._onNavigateDomain(route, domain, method));
     this._router.setRoute(/^$/, this._onNavigateHome.bind(this));
     this._initialize();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "vanilla-protocol-viewer",
+  "version": "0.0.1",
+  "license": "Apache-2",
+  "scripts": {
+    "build": "node scripts/ssr.js"
+  },
+  "dependencies": {
+    "mkdirp": "^0.5.1",
+    "devtools-protocol": "^0.0.522775",
+    "usus": "^1.6.0"
+  }
+}

--- a/scripts/ssr.js
+++ b/scripts/ssr.js
@@ -1,0 +1,36 @@
+
+const fs = require('fs');
+const path = require('path');
+
+const usus = require('usus');
+const mkdirp = require('mkdirp');
+
+const protocols = [
+  require('devtools-protocol/json/browser_protocol.json'),
+  require('devtools-protocol/json/js_protocol.json')
+];
+
+
+(async function() {
+  const chrome = await usus.launchChrome();
+  const ususConfig = {inlineStyles: true, chromePort: chrome.port, delay: 500};
+
+
+  const domainList = [];
+  protocols.forEach(protocolFile => protocolFile.domains.forEach(d => domainList.push(d.domain)));
+
+  for (const domainid of domainList.slice(2)) {
+    const url = `http://localhost:8000/#${domainid}`;
+    console.log(`Loading ${url}...`);
+    const html = await usus.render(url, ususConfig);
+
+    await usus.render('data:text/html,<h3>clearing state</h3>', ususConfig);
+
+    const filename = path.resolve(__dirname, '../tot/', `${domainid}/index.html`);
+    mkdirp.sync(path.dirname(filename));
+    fs.writeFileSync(filename, html, 'utf8');
+    console.log(`Wrote ${html.length} bytes to ${filename}\n`);
+  }
+
+  await chrome.kill();
+})();


### PR DESCRIPTION
This introduces a script which creates rendered editions of each of the domains. 
These pages load just fine in the browser, with full functionality.

This PR doesn't touch routing / the migration of hash to pushState.